### PR TITLE
flush stdout when printing a result

### DIFF
--- a/native/mine.c
+++ b/native/mine.c
@@ -92,6 +92,7 @@ void *do_work(void *ptr)
 				did[24] = 0;
 				pthread_mutex_lock(&stdout_mutex);
 				gmp_printf("%s %s %#Zx\n", did, handle, k_inv[j]);
+				fflush(stdout);
 				pthread_mutex_unlock(&stdout_mutex);
 			}
 		}

--- a/native/mine_nogmp.c
+++ b/native/mine_nogmp.c
@@ -86,6 +86,7 @@ void *do_work(void *ptr)
 						printf("%02x", kinvbuf[k]);
 					}
 					printf("\n");
+					fflush(stdout);
 					pthread_mutex_unlock(&stdout_mutex);
 				}
 			}


### PR DESCRIPTION
this fixes behavior when piping `native/mine` output to `tee` on my system. otherwise you get it all buffered up (no file output or console output) until it's printed like 4kb of data. and also you get a partial line at the end.

tested with `./native/mine_nogmp 32 precomputed.bin $key eeeee | tee out.txt` on arch linux

shouldn't affect performance because it's in the cold path (we only flush when there's a successful mine)